### PR TITLE
Profiles refactor

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -220,7 +220,7 @@ REST_FRAMEWORK = {
         'rest_framework.permissions.IsAuthenticated',  # Must be authenticated for all views
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework_simplejwt.authentication.JWTAuthentication'
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
     ],
 }
 

--- a/backend/profiles/serializers.py
+++ b/backend/profiles/serializers.py
@@ -80,3 +80,27 @@ class UserProfileSerializer(NestedUpdateMixin, serializers.ModelSerializer):
                   'level_of_commitment', 'seeking', 'instruments', 'genres', 'music_samples',
                   'social_media')
         read_only_fields = ('join_date', 'age', 'city', 'state', 'profile_picture')
+
+
+class PublicUserProfileSerializer(serializers.ModelSerializer):
+    """
+    This serializer shows only the UserProfile fields that are public to other users
+    """
+    genres = GenreSerializer(many=True)
+    seeking = InstrumentSerializer(many=True)
+    instruments = UserInstrumentSerializer(source='userinstruments', many=True)
+    gender = GenderSerializer()
+    level_of_commitment = CommitmentLevelSerializer()
+    social_media = SocialMediaLinkSerializer(source='socialmedia', many=True, read_only=True)
+    music_samples = MusicSampleSerializer(source='user.music_sample', many=True, read_only=True)
+
+    try:
+        profile_picture = ProfilePictureSerializer(source='user.profile_pic', read_only=True)
+    except ObjectDoesNotExist:
+        profile_picture = None
+
+    class Meta:
+        model = UserProfile
+        fields = ('id', 'first_name', 'last_name', 'full_name', 'gender', 'zipcode', 'city', 'age',
+                  'state', 'profile_picture', 'years_playing', 'level_of_commitment', 'seeking',
+                  'instruments', 'genres', 'music_samples', 'social_media')

--- a/backend/profiles/views.py
+++ b/backend/profiles/views.py
@@ -3,7 +3,8 @@ from rest_framework.viewsets import ModelViewSet
 from .models import (
     ExperienceLevel,
     UserInstrument,
-    UserProfile, Gender,
+    UserProfile,
+    Gender,
     CommitmentLevel,
     SocialMediaLink
 )
@@ -13,7 +14,8 @@ from .serializers import (
     UserProfileSerializer,
     GenderSerializer,
     CommitmentLevelSerializer,
-    SocialMediaLinkSerializer
+    SocialMediaLinkSerializer,
+    PublicUserProfileSerializer
 )
 
 
@@ -70,7 +72,7 @@ class UserProfileViewSet(ModelViewSet):
     """
     serializer_class = UserProfileSerializer
 
-    # PUT not allowed since only some fields of UserProfile alloed to be updated
+    # PUT not allowed since only some fields of UserProfile allowed to be updated
     http_method_names = ['get', 'patch']
 
     def get_queryset(self):
@@ -80,6 +82,28 @@ class UserProfileViewSet(ModelViewSet):
         user = self.request.user
         return UserProfile.objects.filter(user=user)
 
+    def retrieve(self, request, *args, **kwargs):
+        """
+        If the requesting user and the requested profile match, then returns the entire
+        UserProfile. If the user and requested profile do not match, returns only the
+        fields that are publicly available.
+        """
+        user = request.user
+        requested_profile_id = int(kwargs.get('pk'))
+        profile = UserProfile.objects.get(user=user)
+
+        if profile.id == requested_profile_id:
+            serializer = UserProfileSerializer(profile)
+        else:
+            try:
+                profile = UserProfile.objects.get(id=requested_profile_id)
+            except UserProfile.DoesNotExist:
+                return Response({'detail': 'requested profile does not exist'}, status=404)
+
+            serializer = PublicUserProfileSerializer(profile)
+
+        return Response(serializer.data)
+
     def list(self, request, *args, **kwargs):
         """
         Returns a single UserProfile when a list is requested
@@ -88,3 +112,16 @@ class UserProfileViewSet(ModelViewSet):
         profile = UserProfile.objects.get(user=user)
         serializer = UserProfileSerializer(profile)
         return Response(serializer.data)
+
+    def update(self, request, *args, **kwargs):
+        """
+        Prevent unauthorized user from updating another user's profile
+        """
+        user = request.user
+        requested_profile_id = int(kwargs.get('pk'))
+        profile = UserProfile.objects.get(user=user)
+
+        if profile.id != requested_profile_id:
+            return Response({'detail': 'requestor is not authorized to edit profile that is not their own'}, status=401)
+
+        return super().update(request, *args, **kwargs)

--- a/frontend/src/components/EditProfile/EditProfileForm.tsx
+++ b/frontend/src/components/EditProfile/EditProfileForm.tsx
@@ -556,11 +556,11 @@ function EditProfile() {
             <h2>Edit Profile</h2>
             <div className="form-group">
                 <label htmlFor="first_name">First Name</label>
-                <input type='first_name' name='first_name' id='edit-profile-first' onChange={handleChange} value={profile.first_name} />
+                <input type='first_name' name='first_name' id='edit-profile-first' required onChange={handleChange} value={profile.first_name} />
             </div>
             <div className="form-group">
                 <label htmlFor="last_name">Last Name</label>
-                <input type='last_name' name='last_name' id='edit-profile-last' onChange={handleChange} value={profile.last_name}/>
+                <input type='last_name' name='last_name' id='edit-profile-last' required onChange={handleChange} value={profile.last_name}/>
             </div>
             <div className="form-group">
                 <label htmlFor="gender">Gender</label>
@@ -572,7 +572,7 @@ function EditProfile() {
             </div>
             <div className="form-group">
                 <label htmlFor="zipcode">Zipcode</label>
-                <input type='zipcode' name='zipcode' id='edit-profile-zipcode' onChange={handleChange} value={profile.zipcode}/>
+                <input type='zipcode' name='zipcode' id='edit-profile-zipcode' required onChange={handleChange} value={profile.zipcode}/>
             </div>
             <div className="form-group">
                 {/* Added for spacing */}

--- a/frontend/src/components/ProfilePage/ProfilePage.tsx
+++ b/frontend/src/components/ProfilePage/ProfilePage.tsx
@@ -56,6 +56,14 @@ export default function ProfilePage() {
       return new Date(dateString).toLocaleDateString("en-US", { year: "numeric", month: "long", day: "numeric" })
     }
 
+    const getLocation = () => {
+        if (profile?.city === null || profile?.state === null) {
+            return '';
+        }
+        
+        return `${profile?.city}, ${profile?.state}, ${profile?.zipcode}`
+    }
+
     const getGenres = () => {
         let genreString = '';
 
@@ -127,6 +135,18 @@ export default function ProfilePage() {
             setBandcampLink(bandcampObject.social_media_link);
         }
     }
+
+    const getProfilePicture = async () => {
+        const res = await fetch('/api/profile-pics/', {
+            method: 'GET',
+            headers: {
+              'Content-type': 'application/json',
+              'Authorization': `JWT ${localStorage.getItem('access')}`
+            }
+          });
+        const resJSON = await res.json();
+        setProfilePicture(resJSON.image_file)
+    }
     useEffect(() => {
         const loggedProfileString = window.localStorage.getItem('loggedJamSessionProfile');
 
@@ -143,6 +163,7 @@ export default function ProfilePage() {
         }
         
         getSocialLinks();
+        getProfilePicture();
     },[profile, getSocialLinks])
 
     return (
@@ -203,7 +224,7 @@ export default function ProfilePage() {
 
                     <div className="user-info">
                         <div>
-                            <h3>{`${profile?.city}, ${profile?.state}`}, {profile?.zipcode}</h3>
+                            <h3>{getLocation()}</h3>
                             <h3>Genres:</h3>
                             <p>{getGenres()}</p>
                             <h3>Instruments:</h3> 

--- a/frontend/src/components/UploadMusicModal/UploadMusicModal.css
+++ b/frontend/src/components/UploadMusicModal/UploadMusicModal.css
@@ -38,7 +38,7 @@ body.active-modal {
 .overlay {
     background: rgba(49,49,49,0.8);
 }
-.modal-content {
+.music-modal-content {
     position: absolute;
     top: 40%;
     left: 50%;


### PR DESCRIPTION
Made following changes:
- Modified /profiles endpoint so if the logged-in user attempts to see another user's profile the data returned does not contain sensitive information like birthdate, age, account creation date
- Added function to profiles page to show a blank string if city or state are null to prevent location from showing up as "null, null, "